### PR TITLE
docs: add Global Dev Docs Standard link and cross-repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## License
 
 MIT — See [LICENSE](LICENSE).
+
+## 📚 Documentation
+
+This repository follows the [Global Dev Docs Standard](https://github.com/OpenSIN-AI/Global-Dev-Docs-Standard).
+
+For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For security policy, see [SECURITY.md](SECURITY.md).
+For the complete OpenSIN ecosystem, see [OpenSIN-AI Organization](https://github.com/OpenSIN-AI).
+
+## 🔗 See Also
+
+- [OpenSIN Core](https://github.com/OpenSIN-AI/OpenSIN) — Main platform
+- [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) — CLI
+- [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) — Backend
+- [OpenSIN-Infrastructure](https://github.com/OpenSIN-AI/OpenSIN-Infrastructure) — Deploy
+- [Global Dev Docs Standard](https://github.com/OpenSIN-AI/Global-Dev-Docs-Standard) — Docs


### PR DESCRIPTION
This PR adds the Global Dev Docs Standard link and cross-repo links to the README.